### PR TITLE
fix: Duplicate dropzones assignment to persons

### DIFF
--- a/src/components/gl/House/HotSpots/AppartmentHotspot.tsx
+++ b/src/components/gl/House/HotSpots/AppartmentHotspot.tsx
@@ -112,12 +112,6 @@ export const AppartmentHotspot = ({
           onPointerEnter={handleOnPointerEnter}
           onPointerLeave={handleOnPointerLeave}
           geometry={geometry}
-          // material={materials}
-          // material-tonedMapped={false}
-          // material-emissive={0xffffff}
-          // material-emissiveIntensity={glow}
-          // material-map={materials.map}
-          // material-emissiveMap={materials.map}
           {...props}
           name="Hotspot"
           userData={{ service: hotspotService }}

--- a/src/components/gl/House/HotSpots/AppartmentHotspot.tsx
+++ b/src/components/gl/House/HotSpots/AppartmentHotspot.tsx
@@ -1,13 +1,12 @@
 import { a, easings, useSpring } from '@react-spring/three';
 import { useCursor } from '@react-three/drei';
-import { useFrame, type MeshProps } from '@react-three/fiber';
+import { type MeshProps } from '@react-three/fiber';
 import { useSelector } from '@xstate/react';
 import { useRef, useState } from 'react';
 import { type Mesh } from 'three';
 import { shallow } from 'zustand/shallow';
 import { useGameMachineProvider } from '../../../../hooks/use';
 import { useStoreDragging } from '../../../../stores/storeDragging';
-import { useStoreHotspot } from '../../../../stores/storeHotspots';
 import type { AppartmentHotSpot } from './types';
 
 export const AppartmentHotspot = ({
@@ -20,21 +19,6 @@ export const AppartmentHotspot = ({
   const refMesh = useRef<Mesh>(null);
   const [isHovered, setIsHovered] = useState(false);
 
-  const {
-    getAvailableDropZone,
-    updateDropZoneOccupied,
-    cleanupHotspotDropzoneFromRemovedPersons,
-  } = useStoreHotspot(
-    (state) => ({
-      updateDropZoneOccupied: state.updateDropZoneOccupied,
-      updateHotSpotPosition: state.updateHotSpotPosition,
-      dropzonegetAvailableDropZone: state.getAvailableDropZone,
-      getAvailableDropZone: state.getAvailableDropZone,
-      cleanupHotspotDropzoneFromRemovedPersons:
-        state.cleanupHotspotDropzoneFromRemovedPersons,
-    }),
-    shallow,
-  );
   const gameService = useGameMachineProvider();
   const hotspotService = useSelector(
     gameService,
@@ -43,21 +27,11 @@ export const AppartmentHotspot = ({
 
   const { persons, maxPersons } = useSelector(hotspotService, (s) => s.context);
 
-  useFrame(({ clock }) => {
-    if (Math.floor(clock.getElapsedTime()) % 2 === 0) {
-      cleanupHotspotDropzoneFromRemovedPersons(
-        type,
-        persons.map((p) => p.id),
-      );
-    }
-  });
-
   const {
     draggingActorRef,
     setDraggingActorRef,
     setDraggingId,
     setIsDragging,
-    draggingRef,
   } = useStoreDragging(
     (state) => ({
       draggingRef: state.draggingRef,
@@ -83,15 +57,6 @@ export const AppartmentHotspot = ({
         type: 'onRegisterPerson',
         person: draggingActorRef,
       });
-
-      // save state in mesh userData while machine state isn't fixed
-      const dropZone = getAvailableDropZone(type);
-
-      if (draggingRef?.userData && dropZone) {
-        draggingRef.userData.isIdle = false;
-        draggingRef.userData.dropZone = dropZone;
-        updateDropZoneOccupied(type, dropZone.index, draggingActorRef.id);
-      }
 
       setDraggingId(null);
       setIsDragging(false);

--- a/src/components/gl/Person/Person.tsx
+++ b/src/components/gl/Person/Person.tsx
@@ -276,15 +276,6 @@ export const Person = ({
             },
           }}
         />
-
-        {/* <Text fontSize={0.3} position-y={5.75} color="white">
-          {name}
-          <meshStandardMaterial
-            toneMapped={false}
-            emissive={'#ffffff'}
-            emissiveIntensity={1.2}
-          />
-        </Text> */}
       </group>
       <PersonShadowRecall
         beforeDragPosition={beforeDragPosition.current}

--- a/src/components/gl/Person/Person.tsx
+++ b/src/components/gl/Person/Person.tsx
@@ -1,7 +1,7 @@
 import { a, useSpring } from '@react-spring/three';
 import { useCursor } from '@react-three/drei';
 import { useFrame, type ThreeEvent } from '@react-three/fiber';
-import { useSelector } from '@xstate/react';
+import { useActor, useSelector } from '@xstate/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   BufferGeometry,
@@ -14,13 +14,12 @@ import {
 } from 'three';
 import type { ActorRefFrom } from 'xstate';
 import { shallow } from 'zustand/shallow';
+import { useGameMachineProvider } from '../../../hooks/use';
 import { personMachine } from '../../../machines/person.machine';
 import { useStoreDragging } from '../../../stores/storeDragging';
-import { useStoreHotspot } from '../../../stores/storeHotspots';
 import { PersonShadowRecall } from './PersonShadowRecall';
 import { Statbars } from './Statbars';
 import { PERSON_HEIGHT } from './person.constants';
-import { useGameMachineProvider } from '../../../hooks/use';
 
 const selectFeedbackIntensiry = (
   isHovered: boolean,
@@ -35,6 +34,26 @@ const selectFeedbackIntensiry = (
   return 0;
 };
 
+function useCurrentDropzone(
+  currentHotSpot: 'sofa' | 'bar' | 'dancefloor' | 'buffet' | 'toilet' | null,
+  actorId: string,
+) {
+  const gameService = useGameMachineProvider();
+  const hotspots = useSelector(gameService, (state) => state.context.hotspots);
+  const hotSpot =
+    currentHotSpot !== null ? hotspots[currentHotSpot] : hotspots.lobby;
+
+  const [hotSpotState] = useActor(hotSpot);
+
+  if (currentHotSpot === null) {
+    return null;
+  }
+
+  return hotSpotState?.context.dropzones.find(
+    (dz) => dz.personActorId === actorId,
+  )?.position;
+}
+
 export const Person = ({
   refFloor,
   pos,
@@ -46,16 +65,14 @@ export const Person = ({
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const gameService = useGameMachineProvider();
-  // const hotspots = useSelector(gameService, (state) => state.context.hotspots);
+  const currentHotSpot = useSelector(
+    actor,
+    (state) => state.context.currentHotSpot,
+  );
+
+  const targetDropZone = useCurrentDropzone(currentHotSpot, actor.id);
 
   useCursor(isHovered);
-
-  const { updateDropZoneOccupied, clearHotSpotsDropZonesForActor } =
-    useStoreHotspot((state) => ({
-      updateDropZoneOccupied: state.updateDropZoneOccupied,
-      clearHotSpotsDropZonesForActor: state.clearHotSpotsDropZonesForActor,
-      getAvailableDropZone: state.getAvailableDropZone,
-    }));
 
   const isExists = useRef(false);
 
@@ -82,13 +99,11 @@ export const Person = ({
     shallow,
   );
 
-  const deleteRefOnRemove = (draggingRef: Group) => {
+  const deleteRefOnRemove = () => {
     setIsDragging(false);
     setDraggingId(null);
     setDraggingActorRef(null);
     setDraggingRef(null);
-    draggingRef.userData.isIdle = true;
-    draggingRef.userData.dropZone = null;
   };
 
   useEffect(() => {
@@ -102,7 +117,7 @@ export const Person = ({
         !isPersonExists &&
         draggingRef
       ) {
-        deleteRefOnRemove(draggingRef);
+        deleteRefOnRemove();
       }
     });
   }, []);
@@ -169,17 +184,12 @@ export const Person = ({
     }
 
     // position on not dragged, on active dropzone
-    if (
-      !isBeingDragged &&
-      draggingRef &&
-      draggingRef.userData.isIdle === false &&
-      draggingRef.userData.dropZone.position
-    ) {
-      draggingRef.position.lerp(draggingRef.userData.dropZone.position, 0.1);
+    if (!isBeingDragged && targetDropZone) {
+      refGroup.current.position.lerp(targetDropZone, 0.1);
     }
 
     // position on not dragged and idle
-    if (!isBeingDragged && draggingRef?.userData.isIdle === true) {
+    if (!isBeingDragged) {
       refGroup.current.position.y = MathUtils.lerp(
         refGroup.current.position.y,
         -1.8,
@@ -201,12 +211,9 @@ export const Person = ({
   const handleOnClick = (e: ThreeEvent<MouseEvent>) => {
     e.stopPropagation();
 
-    clearHotSpotsDropZonesForActor(actor.id);
-    if (isBeingDragged && draggingRef) {
-      deleteRefOnRemove(draggingRef);
-
-      return;
-    }
+    actor.send({
+      type: 'onUnregisterFromAllHotspot',
+    });
 
     // find intersects on the sene
     setDraggingRef(refGroup.current);
@@ -214,23 +221,6 @@ export const Person = ({
     setIsDragging(true);
     setDraggingId(actor.id);
     setDraggingActorRef(actor);
-    actor.send({
-      type: 'onUnregisterFromAllHotspot',
-    });
-
-    if (
-      draggingRef &&
-      draggingRef.userData.dropZone &&
-      draggingRef.userData.isIdle
-    ) {
-      updateDropZoneOccupied(
-        draggingRef.userData.dropZone.hotspotType,
-        draggingRef.userData.dropZone.index,
-        null,
-      );
-      draggingRef.userData.isIdle = true;
-      draggingRef.userData.dropZone = null;
-    }
   };
 
   return (

--- a/src/machines/bar.machine.ts
+++ b/src/machines/bar.machine.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from 'three';
 import { hotspotMachine } from './hotspot.machine';
 
 export const barMachine = hotspotMachine
@@ -5,6 +6,38 @@ export const barMachine = hotspotMachine
     ...hotspotMachine.context,
     maxPersons: 5,
     name: 'bar',
+    dropzones: [
+      {
+        position: new Vector3(4.2, -1.8, 3.8),
+        personActorId: null,
+        index: 0,
+        hotspotType: 'bar',
+      },
+      {
+        position: new Vector3(4.2, -1.8, 6.5),
+        personActorId: null,
+        index: 1,
+        hotspotType: 'bar',
+      },
+      {
+        position: new Vector3(6.9, -1.8, 8.6),
+        personActorId: null,
+        index: 2,
+        hotspotType: 'bar',
+      },
+      {
+        position: new Vector3(4.7, -1.8, 8.6),
+        personActorId: null,
+        index: 3,
+        hotspotType: 'bar',
+      },
+      {
+        position: new Vector3(10, -1.8, 10.2),
+        personActorId: null,
+        index: 4,
+        hotspotType: 'bar',
+      },
+    ],
   })
   .withConfig({
     actions: {

--- a/src/machines/buffet.machine.ts
+++ b/src/machines/buffet.machine.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from 'three';
 import { hotspotMachine } from './hotspot.machine';
 
 export const buffetMachine = hotspotMachine
@@ -5,6 +6,38 @@ export const buffetMachine = hotspotMachine
     ...hotspotMachine.context,
     maxPersons: 5,
     name: 'buffet',
+    dropzones: [
+      {
+        position: new Vector3(22, -1.8, 9),
+        personActorId: null,
+        index: 0,
+        hotspotType: 'buffet',
+      },
+      {
+        position: new Vector3(27, -1.8, 10),
+        personActorId: null,
+        index: 1,
+        hotspotType: 'buffet',
+      },
+      {
+        position: new Vector3(31, -1.8, 10),
+        personActorId: null,
+        index: 2,
+        hotspotType: 'buffet',
+      },
+      {
+        position: new Vector3(38, -1.8, 7),
+        personActorId: null,
+        index: 3,
+        hotspotType: 'buffet',
+      },
+      {
+        position: new Vector3(26, -1.8, 4),
+        personActorId: null,
+        index: 4,
+        hotspotType: 'buffet',
+      },
+    ],
   })
   .withConfig({
     actions: {

--- a/src/machines/dancefloor.machine.ts
+++ b/src/machines/dancefloor.machine.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from 'three';
 import { hotspotMachine } from './hotspot.machine';
 
 export const dancefloorMachine = hotspotMachine
@@ -5,6 +6,32 @@ export const dancefloorMachine = hotspotMachine
     ...hotspotMachine.context,
     maxPersons: 4,
     name: 'dancefloor',
+    dropzones: [
+      {
+        position: new Vector3(-7, -1.8, 4.5),
+        personActorId: null,
+        index: 0,
+        hotspotType: 'dancefloor',
+      },
+      {
+        position: new Vector3(-4.9, -1.8, 6.5),
+        personActorId: null,
+        index: 1,
+        hotspotType: 'dancefloor',
+      },
+      {
+        position: new Vector3(-2.8, -1.8, 4.9),
+        personActorId: null,
+        index: 2,
+        hotspotType: 'dancefloor',
+      },
+      {
+        position: new Vector3(0, -1.8, 4.6),
+        personActorId: null,
+        index: 3,
+        hotspotType: 'dancefloor',
+      },
+    ],
   })
   .withConfig({
     actions: {

--- a/src/machines/hotspot.machine.ts
+++ b/src/machines/hotspot.machine.ts
@@ -1,87 +1,130 @@
 import { type ActorRefFrom, assign, createMachine, sendParent } from 'xstate';
 import { personMachine } from './person.machine';
+import type { Vector3 } from 'three';
 
-export const hotspotMachine = createMachine(
-  {
-    /** @xstate-layout N4IgpgJg5mDOIC5QAkD2AXWAHDBiVAdgIIQQAKYATrIQNoAMAuoqDrAJbruEsgAeiALQAmAIwBWAHTCAHKOHiAzPRnCAbAHYtwgDQgAnolH0NkgJz01wsQBZFcs2dkBfZ3rSYc6fAQBKYAFtUADcwCmo6Jl42Tm4CXgEERXFhSWVxDUUNYXphDRszGQ09QwQNNTSzcTV6Gy1jezNXdwxsPEIAVSwIAEN0MKoaAgZmJBAYrh4xxNEbGXMxItFM4SdakqE1cWaQDzb0SS7ergIocKHYXD5YdD6wSR6AM37KAApjenoASlw9r0Pun12KdzoRYCNoqgOJN4tMjKpzCk5EplA1rBsEDZcpINDJFPIPmo7AVtjsCKgIHBeH8MJDoXEEogsZI1MtRGotvRCuJRHIMQpRNI8fINJZHLM1DsaQcjkCQYMwXTYlNQIkZPNWRp2ZzubzRBilBV8cI5iozKJ5IobK5XEA */
-    id: 'Hotspot',
-    description:
-      'A hotspot is a point of interest where you can drop a person to interact with the it.',
-    context: {
-      maxPersons: 3,
-      persons: [],
-      name: 'GenericHotspot',
-    },
-    initial: 'Ticking',
-    states: {
-      Inactive: {
-        on: {
-          triggerStart: 'Ticking',
-        },
+export const hotspotMachine = createMachine({
+  /** @xstate-layout N4IgpgJg5mDOIC5QAkD2AXWAHDBiVAdgIIQQAKYATrIQNoAMAuoqDrAJbruEsgAeiALQAmAIwBWAHTCAHKOHiAzPRnCAbAHYtwgDQgAnolH0NkgJz01wsQBZFcs2dkBfZ3rSYc6fAQBKYAFtUADcwCmo6Jl42Tm4CXgEERXFhSWVxDUUNYXphDRszGQ09QwQNNTSzcTV6Gy1jezNXdwxsPEIAVSwIAEN0MKoaAgZmJBAYrh4xxNEbGXMxItFM4SdakqE1cWaQDzb0SS7ergIocKHYXD5YdD6wSR6AM37KAApjenoASlw9r0Pun12KdzoRYCNoqgOJN4tMjKpzCk5EplA1rBsEDZcpINDJFPIPmo7AVtjsCKgIHBeH8MJDoXEEogsZI1MtRGotvRCuJRHIMQpRNI8fINJZHLM1DsaQcjkCQYMwXTYlNQIkZPNWRp2ZzubzRBilBV8cI5iozKJ5IobK5XEA */
+  id: 'Hotspot',
+  description:
+    'A hotspot is a point of interest where you can drop a person to interact with the it.',
+  context: {
+    maxPersons: 3,
+    persons: [],
+    name: 'GenericHotspot',
+    dropzones: [],
+  },
+  initial: 'Ticking',
+  states: {
+    Inactive: {
+      on: {
+        triggerStart: 'Ticking',
       },
-      Ticking: {
-        on: {
-          triggerPause: 'Inactive',
-        },
-        entry: ["updatePersons", sendParent((context) => ({
+    },
+    Ticking: {
+      on: {
+        triggerPause: 'Inactive',
+      },
+      entry: [
+        'updatePersons',
+        sendParent((context) => ({
           type: 'onIncrementHype',
           hype: context.persons.length < 1 ? 0 : context.persons.length * 5,
-        }))],
-        after: {
-          '500': 'Ticking'
-        },
+        })),
+      ],
+      after: {
+        '500': 'Ticking',
       },
     },
-    on: {
-      onRegisterPerson: {
-        actions: assign((context, event) => {
-          // console.log(
-          //   'hotspot.onRegisterPerson - adding the person to the hotspot context',
-          // );
-          if (context.persons.find((e) => e.id === event.person.id)) {
-            return context;
-          }
-          return {
-            ...context,
-            persons: [...context.persons, event.person],
-          };
-        }),
-        // actions: 'test',
-      },
-      onUnregisterPerson: {
-        actions: assign((context, event) => {
-          // console.log(
-          //   'hotspot.onUnregisterPerson - removing the person to the hotspot context',
-          // );
-          return {
-            ...context,
-            persons: context.persons.filter((p) => p.id !== event.person.id),
-          };
-        }),
-      },
+  },
+  on: {
+    onRegisterPerson: {
+      actions: assign((context, event) => {
+        // console.log(
+        //   'hotspot.onRegisterPerson - adding the person to the hotspot context',
+        // );
+        if (context.persons.find((e) => e.id === event.person.id)) {
+          return context;
+        }
+
+        const availableDropzone = context.dropzones.find(
+          (dz) => dz.personActorId === null,
+        );
+
+        return {
+          ...context,
+          dropzones: context.dropzones.map((dz) => {
+            if (dz.index === availableDropzone?.index) {
+              return {
+                ...dz,
+                personActorId: event.person.id,
+              };
+            }
+            return dz;
+          }),
+          persons: [...context.persons, event.person],
+        };
+      }),
+      // actions: 'test',
     },
-    schema: {
-      context: {} as {
-        persons: ActorRefFrom<typeof personMachine>[];
-        maxPersons: number;
-        name: string;
-      },
-      events: {} as
-        | { type: 'triggerStart' }
-        | { type: 'triggerPause' }
-        | { type: 'onUpdatePerson' }
-        | {
+    onUnregisterPerson: {
+      actions: assign((context, event) => {
+        // console.log(
+        //   'hotspot.onUnregisterPerson - removing the person to the hotspot context',
+        // );
+
+        const occupiedDropzone = context.dropzones.find(
+          (dz) => dz.personActorId === event.person.id,
+        );
+
+        return {
+          ...context,
+          dropzones: context.dropzones.map((dz) => {
+            if (dz.index === occupiedDropzone?.index) {
+              return {
+                ...dz,
+                personActorId: null,
+              };
+            }
+            return dz;
+          }),
+          persons: context.persons.filter((p) => p.id !== event.person.id),
+        };
+      }),
+    },
+  },
+  schema: {
+    context: {} as {
+      persons: ActorRefFrom<typeof personMachine>[];
+      maxPersons: number;
+      name: string;
+      dropzones: Array<{
+        position: Vector3;
+        personActorId: string | null;
+        index: number;
+        hotspotType:
+          | 'lobby'
+          | 'bar'
+          | 'dancefloor'
+          | 'toilet'
+          | 'sofa'
+          | 'buffet';
+      }>;
+    },
+    events: {} as
+      | { type: 'triggerStart' }
+      | { type: 'triggerPause' }
+      | { type: 'onUpdatePerson' }
+      | {
           type: 'onRegisterPerson';
           person: ActorRefFrom<typeof personMachine>;
         }
-        | {
+      | {
           type: 'onUnregisterPerson';
           person: ActorRefFrom<typeof personMachine>;
         },
-      actions: {} as { type: 'updatePersons' } | { type: 'updateHype' },
-    },
-    predictableActionArguments: true,
-    preserveActionOrder: true,
-    tsTypes: {} as import('./hotspot.machine.typegen').Typegen0,
-  }
-);
+    actions: {} as { type: 'updatePersons' } | { type: 'updateHype' },
+  },
+  predictableActionArguments: true,
+  preserveActionOrder: true,
+  tsTypes: {} as import('./hotspot.machine.typegen').Typegen0,
+});

--- a/src/machines/lobby.machine.ts
+++ b/src/machines/lobby.machine.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from 'three';
 import { hotspotMachine } from './hotspot.machine';
 
 export const lobbyMachine = hotspotMachine
@@ -5,6 +6,26 @@ export const lobbyMachine = hotspotMachine
     ...hotspotMachine.context,
     maxPersons: 3,
     name: 'lobby',
+    dropzones: [
+      {
+        position: new Vector3(-19, -1.8, 6.8),
+        personActorId: null,
+        index: 0,
+        hotspotType: 'lobby',
+      },
+      {
+        position: new Vector3(-16, -1.8, 7),
+        personActorId: null,
+        index: 1,
+        hotspotType: 'lobby',
+      },
+      {
+        position: new Vector3(-13, -1.8, 2.5),
+        personActorId: null,
+        index: 2,
+        hotspotType: 'lobby',
+      },
+    ],
   })
   .withConfig({
     actions: {

--- a/src/machines/person.machine.ts
+++ b/src/machines/person.machine.ts
@@ -46,6 +46,7 @@ export const personMachine = createMachine(
     context: {
       name: '',
       self: null as unknown,
+      currentHotSpot: null,
       meters: {
         fun: METERS_CONFIG.fun.initialValue,
         satiety: METERS_CONFIG.satiety.initialValue,
@@ -72,6 +73,7 @@ export const personMachine = createMachine(
               // console.log('pissing, updating meters', context.name);
               return {
                 ...context,
+                currentHotSpot: 'toilet' as const,
                 meters: {
                   ...context.meters,
                   urine: METERS_CONFIG.urine.clamp(
@@ -88,6 +90,7 @@ export const personMachine = createMachine(
               // console.log('drinking, updating meters', context.name);
               return {
                 ...context,
+                currentHotSpot: 'bar' as const,
                 meters: {
                   ...context.meters,
                   hydration: METERS_CONFIG.hydration.clamp(
@@ -112,11 +115,14 @@ export const personMachine = createMachine(
 
               return {
                 ...context,
+                currentHotSpot: 'dancefloor' as const,
                 meters: {
                   ...context.meters,
-                  fun: shouldntEarnFun ? context.meters.fun : METERS_CONFIG.fun.clamp(
-                    context.meters.fun + METERS_CONFIG.fun.step * 3,
-                  ),
+                  fun: shouldntEarnFun
+                    ? context.meters.fun
+                    : METERS_CONFIG.fun.clamp(
+                        context.meters.fun + METERS_CONFIG.fun.step * 3,
+                      ),
                   satiety: METERS_CONFIG.satiety.clamp(
                     context.meters.satiety - METERS_CONFIG.satiety.step,
                   ),
@@ -137,11 +143,14 @@ export const personMachine = createMachine(
 
               return {
                 ...context,
+                currentHotSpot: 'sofa' as const,
                 meters: {
                   ...context.meters,
-                  fun: shouldntEarnFun ? context.meters.fun : METERS_CONFIG.fun.clamp(
-                    context.meters.fun + METERS_CONFIG.fun.step * 1.5,
-                  ),
+                  fun: shouldntEarnFun
+                    ? context.meters.fun
+                    : METERS_CONFIG.fun.clamp(
+                        context.meters.fun + METERS_CONFIG.fun.step * 1.5,
+                      ),
                   hydration: METERS_CONFIG.hydration.clamp(
                     context.meters.hydration - METERS_CONFIG.hydration.step,
                   ),
@@ -156,6 +165,7 @@ export const personMachine = createMachine(
               // console.log('Eating, updating meters', context.name);
               return {
                 ...context,
+                currentHotSpot: 'buffet' as const,
                 meters: {
                   ...context.meters,
                   satiety: METERS_CONFIG.satiety.clamp(
@@ -172,6 +182,7 @@ export const personMachine = createMachine(
         initial: 'Idle',
         states: {
           Idle: {
+            entry: 'onIdle',
             after: {
               '500': [
                 {
@@ -248,6 +259,13 @@ export const personMachine = createMachine(
       context: {} as {
         name: string;
         self: unknown;
+        currentHotSpot:
+          | 'sofa'
+          | 'dancefloor'
+          | 'bar'
+          | 'buffet'
+          | 'toilet'
+          | null;
         meters: {
           fun: number; // more is good
           hydration: number; // more is good
@@ -274,6 +292,12 @@ export const personMachine = createMachine(
   },
   {
     actions: {
+      onIdle: assign((context) => {
+        return {
+          ...context,
+          currentHotSpot: null,
+        };
+      }),
       updateMeters: assign((context) => {
         const shouldLoseFunFaster =
           context.meters.hydration <= 0 ||

--- a/src/machines/person.machine.typegen.ts
+++ b/src/machines/person.machine.typegen.ts
@@ -19,6 +19,16 @@ export interface Typegen0 {
     services: never;
   };
   eventsCausingActions: {
+    onIdle:
+      | 'onBar'
+      | 'onBuffet'
+      | 'onDancefloor'
+      | 'onSofa'
+      | 'onToilet'
+      | 'onUnregisterFromAllHotspot'
+      | 'xstate.after(500)#Person.actionFlow.Idle'
+      | 'xstate.after(500)#Person.meterFlow.Active'
+      | 'xstate.init';
     updateMeters: 'xstate.after(500)#Person.meterFlow.Active';
   };
   eventsCausingDelays: {};

--- a/src/machines/sofa.machine.ts
+++ b/src/machines/sofa.machine.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from 'three';
 import { hotspotMachine } from './hotspot.machine';
 
 export const sofaMachine = hotspotMachine
@@ -5,6 +6,32 @@ export const sofaMachine = hotspotMachine
     ...hotspotMachine.context,
     maxPersons: 4,
     name: 'sofa',
+    dropzones: [
+      {
+        position: new Vector3(-13, -1.8, 7.9),
+        personActorId: null,
+        index: 0,
+        hotspotType: 'sofa',
+      },
+      {
+        position: new Vector3(-18, -1.8, 6.7),
+        personActorId: null,
+        index: 1,
+        hotspotType: 'sofa',
+      },
+      {
+        position: new Vector3(-11, -1.8, 5.1),
+        personActorId: null,
+        index: 2,
+        hotspotType: 'sofa',
+      },
+      {
+        position: new Vector3(-16, -1.8, 0.8),
+        personActorId: null,
+        index: 3,
+        hotspotType: 'sofa',
+      },
+    ],
   })
   .withConfig({
     actions: {

--- a/src/machines/toilet.machine.ts
+++ b/src/machines/toilet.machine.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from 'three';
 import { hotspotMachine } from './hotspot.machine';
 
 export const toiletMachine = hotspotMachine
@@ -5,6 +6,14 @@ export const toiletMachine = hotspotMachine
     ...hotspotMachine.context,
     maxPersons: 1,
     name: 'toilet',
+    dropzones: [
+      {
+        position: new Vector3(55, -1.8, 2.7),
+        personActorId: null,
+        index: 0,
+        hotspotType: 'toilet',
+      },
+    ],
   })
   .withConfig({
     actions: {

--- a/src/stores/storeHotspots.ts
+++ b/src/stores/storeHotspots.ts
@@ -12,16 +12,8 @@ export const hotspots = [
 import { Vector3 } from 'three';
 import { create } from 'zustand';
 
-type Dropzone = {
-  position: Vector3;
-  index: number;
-  personActorId: string | null;
-  hotspotType: (typeof hotspots)[number];
-};
-
 type HotSpotWithDropSpots = {
   position: Vector3;
-  dropzones: Dropzone[];
 };
 type Hotspots = Record<(typeof hotspots)[number], HotSpotWithDropSpots>;
 
@@ -31,19 +23,6 @@ type InitialState = {
 };
 
 type Actions = {
-  cleanupHotspotDropzoneFromRemovedPersons: (
-    hotspotType: (typeof hotspots)[number],
-    allExistingPersons: string[],
-  ) => void;
-  getAvailableDropZone: (
-    hotspot: (typeof hotspots)[number],
-  ) => Dropzone | undefined;
-  clearHotSpotsDropZonesForActor: (actorRefId: string) => void;
-  updateDropZoneOccupied: (
-    hotspot: (typeof hotspots)[number],
-    index: number,
-    actorRefId: string | null, // on null, empty
-  ) => void;
   updateHotSpotPosition: (
     hotspot: (typeof hotspots)[number],
     position: Vector3,
@@ -54,261 +33,28 @@ const InitialState: InitialState = {
   hotspots: {
     lobby: {
       position: new Vector3(-30, 0, 0),
-      dropzones: [
-        {
-          position: new Vector3(-19, -1.8, 6.8),
-          personActorId: null,
-          index: 0,
-          hotspotType: 'lobby',
-        },
-        {
-          position: new Vector3(-16, -1.8, 7),
-          personActorId: null,
-          index: 1,
-          hotspotType: 'lobby',
-        },
-        {
-          position: new Vector3(-13, -1.8, 2.5),
-          personActorId: null,
-          index: 2,
-          hotspotType: 'lobby',
-        },
-        {
-          position: new Vector3(-11, -1.8, 4.5),
-          personActorId: null,
-          index: 3,
-          hotspotType: 'lobby',
-        },
-      ],
     },
     bar: {
       position: new Vector3(10, 0, 0),
-      dropzones: [
-        {
-          position: new Vector3(4.2, -1.8, 3.8),
-          personActorId: null,
-          index: 0,
-          hotspotType: 'bar',
-        },
-        {
-          position: new Vector3(4.2, -1.8, 6.5),
-          personActorId: null,
-          index: 1,
-          hotspotType: 'bar',
-        },
-        {
-          position: new Vector3(6.9, -1.8, 8.6),
-          personActorId: null,
-          index: 2,
-          hotspotType: 'bar',
-        },
-        {
-          position: new Vector3(4.7, -1.8, 8.6),
-          personActorId: null,
-          index: 3,
-          hotspotType: 'bar',
-        },
-        {
-          position: new Vector3(10, -1.8, 10.2),
-          personActorId: null,
-          index: 4,
-          hotspotType: 'bar',
-        },
-      ],
     },
     sofa: {
       position: new Vector3(-15, 0, 0),
-      dropzones: [
-        {
-          position: new Vector3(-13, -1.8, 7.9),
-          personActorId: null,
-          index: 0,
-          hotspotType: 'sofa',
-        },
-        {
-          position: new Vector3(-18, -1.8, 6.7),
-          personActorId: null,
-          index: 1,
-          hotspotType: 'sofa',
-        },
-        {
-          position: new Vector3(-11, -1.8, 5.1),
-          personActorId: null,
-          index: 2,
-          hotspotType: 'sofa',
-        },
-        {
-          position: new Vector3(-16, -1.8, 0.8),
-          personActorId: null,
-          index: 3,
-          hotspotType: 'sofa',
-        },
-      ],
     },
     dancefloor: {
       position: new Vector3(-2, 0, 0),
-      dropzones: [
-        {
-          position: new Vector3(-7, -1.8, 4.5),
-          personActorId: null,
-          index: 0,
-          hotspotType: 'dancefloor',
-        },
-        {
-          position: new Vector3(-4.9, -1.8, 6.5),
-          personActorId: null,
-          index: 1,
-          hotspotType: 'dancefloor',
-        },
-        {
-          position: new Vector3(-2.8, -1.8, 4.9),
-          personActorId: null,
-          index: 2,
-          hotspotType: 'dancefloor',
-        },
-        {
-          position: new Vector3(0, -1.8, 4.6),
-          personActorId: null,
-          index: 3,
-          hotspotType: 'dancefloor',
-        },
-      ],
     },
     buffet: {
       position: new Vector3(30, 0, 0),
-      dropzones: [
-        {
-          position: new Vector3(22, -1.8, 9),
-          personActorId: null,
-          index: 0,
-          hotspotType: 'buffet',
-        },
-        {
-          position: new Vector3(27, -1.8, 10),
-          personActorId: null,
-          index: 1,
-          hotspotType: 'buffet',
-        },
-        {
-          position: new Vector3(31, -1.8, 10),
-          personActorId: null,
-          index: 2,
-          hotspotType: 'buffet',
-        },
-        {
-          position: new Vector3(38, -1.8, 7),
-          personActorId: null,
-          index: 3,
-          hotspotType: 'buffet',
-        },
-        {
-          position: new Vector3(26, -1.8, 4),
-          personActorId: null,
-          index: 4,
-          hotspotType: 'buffet',
-        },
-      ],
     },
     toilet: {
       position: new Vector3(50, 0, 0),
-      dropzones: [
-        {
-          position: new Vector3(55, -1.8, 2.7),
-          personActorId: null,
-          index: 0,
-          hotspotType: 'toilet',
-        },
-      ],
     },
   },
   names: ['lobby', 'sofa', 'dancefloor', 'bar', 'buffet', 'toilet'],
 };
 
-export const useStoreHotspot = create<InitialState & Actions>((set, get) => ({
+export const useStoreHotspot = create<InitialState & Actions>((set) => ({
   ...InitialState,
-
-  getAvailableDropZone(hotspot) {
-    // console.log(hotspot);
-    // console.log(get().hotspots[hotspot].dropzones);
-    return get().hotspots[hotspot].dropzones.find(
-      (d) => d.personActorId === null,
-    );
-  },
-
-  clearHotSpotsDropZonesForActor(actorRefId) {
-    set((state) => {
-      const hotspots = { ...state.hotspots };
-      Object.keys(hotspots).forEach((hotspotKey) => {
-        const key = hotspotKey as keyof Hotspots;
-        const dropzones = [...hotspots[key].dropzones];
-        const dropzone = dropzones.find((d) => d.personActorId === actorRefId);
-        if (dropzone) {
-          dropzone.personActorId = null;
-        }
-        hotspots[key].dropzones = dropzones;
-      });
-      return {
-        hotspots,
-      };
-    });
-  },
-
-  cleanupHotspotDropzoneFromRemovedPersons(hotspotType, allExistingPersons) {
-    // console.log(allExistingPersons);
-    set((state) => {
-      const hotspot = state.hotspots[hotspotType];
-
-      const dropzonesWithRemovedPersons = Array.from(hotspot.dropzones).map(
-        (dropzone) => {
-          const d = dropzone;
-          const personInDropzoneStillExists = allExistingPersons.find(
-            (p) => p === d.personActorId,
-          );
-
-          if (!personInDropzoneStillExists && d.personActorId !== null) {
-            // console.log('cleanup removd person');
-            d.personActorId = null;
-          }
-          return d;
-        },
-      );
-      return {
-        hotspots: {
-          ...state.hotspots,
-          [hotspotType]: {
-            ...state.hotspots[hotspotType],
-            dropzones: dropzonesWithRemovedPersons,
-          },
-        },
-      };
-    });
-  },
-
-  updateDropZoneOccupied(hotspotType, index, actorRefId) {
-    return set((state) => {
-      const dropzones = [...state.hotspots[hotspotType].dropzones];
-      // find actorRefId in dropzones and remove of it if it exists
-
-      const alreadyOccupiedByActor = dropzones.find(
-        (d) => d.personActorId === actorRefId,
-      );
-      if (alreadyOccupiedByActor) {
-        alreadyOccupiedByActor.personActorId = null;
-      }
-
-      dropzones[index].personActorId = actorRefId;
-
-      return {
-        hotspots: {
-          ...state.hotspots,
-          [hotspotType]: {
-            ...state.hotspots[hotspotType],
-            dropzones,
-          },
-        },
-      };
-    });
-  },
 
   updateHotSpotPosition(hotspot, position) {
     set((state) => ({


### PR DESCRIPTION
This PR fixes dropzones being assigned to Persons on hotspot drop.
Currently, assigned dropzones might already be occupied.

New approach leverages machines to keep track of dropzones availability.